### PR TITLE
Rename PriorElement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,18 +348,18 @@ impl<I: Iterator> PeekMoreIterator<I> {
     }
 
     /// Try to peek at a previous element. If no such element exists (i.e. our peek view is already
-    /// at the same point as the next iterator element), it will return [`PriorElement::Consumed`].
-    /// If a previous element does exist, [`PriorElement::Peekable`] is returned.
+    /// at the same point as the next iterator element), it will return [`Element::Consumed`].
+    /// If a previous element does exist, [`Element::Peekable`] is returned.
     ///
-    /// [`PriorElement::Consumed`]: enum.PriorElement.html#variant.Consumed
-    /// [`PriorElement::Peekable`]: enum.PriorElement.html#variant.Peekable
+    /// [`Element::Consumed`]: enum.Element.html#variant.Consumed
+    /// [`Element::Peekable`]: enum.Element.html#variant.Peekable
     #[inline]
-    pub fn peek_previous(&mut self) -> PeekElement<Option<&I::Item>> {
+    pub fn peek_previous(&mut self) -> Element<Option<&I::Item>> {
         if self.needle >= 1 {
             self.decrement_needle();
-            PeekElement::Peekable(self.peek())
+            Element::Peekable(self.peek())
         } else {
-            PeekElement::Consumed
+            Element::Consumed
         }
     }
 
@@ -456,7 +456,7 @@ impl<I: FusedIterator> FusedIterator for PeekMoreIterator<I> {}
 /// Type which communicates that no element can exist (because it has been consumed).
 /// Created to differentiate from the Option::None which communicates that an iterator is finished.
 #[derive(Debug, Eq, PartialEq)]
-pub enum PeekElement<T> {
+pub enum Element<T> {
     /// An element which we can peek at exists.
     Peekable(T),
 
@@ -464,7 +464,7 @@ pub enum PeekElement<T> {
     Consumed,
 }
 
-impl<T> PeekElement<T> {
+impl<T> Element<T> {
     /// Release the power of the Option type.
     ///
     /// Mapping:
@@ -472,8 +472,8 @@ impl<T> PeekElement<T> {
     /// - Consumed maps to None.
     pub fn into_option(self) -> Option<T> {
         match self {
-            PeekElement::Peekable(k) => Some(k),
-            PeekElement::Consumed => None,
+            Element::Peekable(k) => Some(k),
+            Element::Consumed => None,
         }
     }
 }
@@ -751,15 +751,15 @@ mod tests {
         assert_eq!(value, &&3);
 
         let peek = iter.peek_previous(); // 2
-        assert_eq!(peek, PeekElement::Peekable(Some(&&2)));
+        assert_eq!(peek, Element::Peekable(Some(&&2)));
         assert_eq!(iter.needle_position(), 1);
 
         let peek = iter.peek_previous(); // 1
-        assert_eq!(peek, PeekElement::Peekable(Some(&&1)));
+        assert_eq!(peek, Element::Peekable(Some(&&1)));
         assert_eq!(iter.needle_position(), 0);
 
         let peek = iter.peek_previous();
-        assert_eq!(peek, PeekElement::Consumed);
+        assert_eq!(peek, Element::Consumed);
         assert_eq!(iter.needle_position(), 0);
     }
 
@@ -785,23 +785,23 @@ mod tests {
         assert_eq!(iter.needle_position(), 3);
 
         let peek = iter.peek_previous(); // None (2)
-        assert_eq!(peek, PeekElement::Peekable(None));
+        assert_eq!(peek, Element::Peekable(None));
         assert_eq!(iter.needle_position(), 2);
 
         let peek = iter.peek_previous(); // None (1)
-        assert_eq!(peek, PeekElement::Peekable(None));
+        assert_eq!(peek, Element::Peekable(None));
         assert_eq!(iter.needle_position(), 1);
 
         let peek = iter.peek_previous(); // 1
-        assert_eq!(peek, PeekElement::Peekable(Some(&&1)));
+        assert_eq!(peek, Element::Peekable(Some(&&1)));
         assert_eq!(iter.needle_position(), 0);
 
         let peek = iter.peek_previous();
-        assert_eq!(peek, PeekElement::Consumed);
+        assert_eq!(peek, Element::Consumed);
         assert_eq!(iter.needle_position(), 0);
 
         let peek = iter.peek_previous();
-        assert_eq!(peek, PeekElement::Consumed);
+        assert_eq!(peek, Element::Consumed);
         assert_eq!(iter.needle_position(), 0);
     }
 }
@@ -813,7 +813,7 @@ mod tests_prior_element {
     #[test]
     fn from_prior_element_into_some() {
         type Int = i32;
-        let prior: PeekElement<Int> = PeekElement::Peekable(1);
+        let prior: Element<Int> = Element::Peekable(1);
         let option: Option<Int> = prior.into_option();
 
         assert_eq!(option, Some(1i32));
@@ -822,7 +822,7 @@ mod tests_prior_element {
     #[test]
     fn from_prior_element_into_none() {
         type Int = i32;
-        let prior: PeekElement<Int> = PeekElement::Consumed;
+        let prior: Element<Int> = Element::Consumed;
         let option: Option<Int> = prior.into_option();
 
         assert_eq!(option, None);


### PR DESCRIPTION
Prior focuses to much on the direct previous element; we also want to use the same enum for `k` previous elements