### PR TITLE
Remove Element and use a Result instead.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,7 +477,7 @@ pub enum PeekMoreError {
     /// This error case will be returned if we try to move to an element, but it has already been
     /// consumed by the iterator.
     /// We can only peek at elements which haven't been consumed.
-    ElementHasBeenConsumed
+    ElementHasBeenConsumed,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Using a result feels more natural, and Result has a powerful pool of
methods which can be used directly.

This change introduces the PeekMoreError which replaces the
'Element::Consumed' with 'PeekMoreError::ElementHasBeenConsumed'