### PR TITLE
patchset-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,12 @@ jobs:
       # don't run doc tests on pinned, since pinned is currently Rust 1.36, but cfg(doctest) requires Rust 1.40
       - if: matrix.build != 'pinned'
         run: cargo doc --verbose
+
+      # test with default features
       - run: cargo test --verbose
 
-      # If we are on a nightly version, we also want to build + test with smallvec
-      - if: matrix.build == 'nightly'
-        run: cargo build --verbose --features smallvec
-      - if: matrix.build == 'nightly'
-        run: cargo test --verbose --features smallvec
+      # test bare
+      - run: cargo test --verbose --no-default-features
 
   rustfmt:
     name: rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,6 @@ default = []
 # smallvec with no-std requires nightly.
 # see https://github.com/servo/rust-smallvec/issues/160
 [dependencies.smallvec]
-version = "0.6.10"
+version = "1.4.0"
 optional = true
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peekmore"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["foresterre <garm@ilumeo.com>"]
 description = "Iterator which can peek forward multiple elements."
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,8 @@ categories = ["no-std"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = []
+default = ["smallvec"]
 
-# smallvec with no-std requires nightly.
-# see https://github.com/servo/rust-smallvec/issues/160
 [dependencies.smallvec]
 version = "1.4.0"
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,8 +379,6 @@ impl<I: Iterator> PeekMoreIterator<I> {
     /// [`PeekMoreError::ElementHasBeenConsumed`].
     /// If a previous element does exist, an option wrapped in an `Ok` result will be returned.
     ///
-    ///  `Result` is re
-    ///
     /// [`PeekMoreError::ElementHasBeenConsumed`]: enum.PeekMoreError.html#variant.ElementHasBeenConsumed
     #[inline]
     pub fn peek_previous(&mut self) -> Result<Option<&I::Item>, PeekMoreError> {
@@ -502,7 +500,10 @@ impl<I: Iterator> PeekMoreIterator<I> {
     ///
     /// [`move_backward_or_reset`]: struct.PeekMoreIterator.html#method.move_backward_or_reset
     #[inline]
-    pub fn move_cursor_back_by(&mut self, n: usize) -> Result<&mut PeekMoreIterator<I>, PeekMoreError> {
+    pub fn move_cursor_back_by(
+        &mut self,
+        n: usize,
+    ) -> Result<&mut PeekMoreIterator<I>, PeekMoreError> {
         if self.cursor < n {
             Err(PeekMoreError::ElementHasBeenConsumed)
         } else {


### PR DESCRIPTION
* Improve naming consistency, especially regarding the cursor
* Bump SmallVec to a version compatible with liballoc on the stable compiler
* Use SmallVec by default

closes #9 