### PR TITLE
Add a first benchmark for peeking within the smallvec stack size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,10 @@ default = ["smallvec"]
 version = "1.4.0"
 optional = true
 default-features = false
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "peek_bench"
+harness = false

--- a/benches/peek_bench.rs
+++ b/benches/peek_bench.rs
@@ -1,0 +1,37 @@
+// A first benchmark for peekmore
+// The outcomes should not be relied upon (yet)
+//
+// TODO: improve benchmark suite
+
+use criterion::black_box;
+use criterion::Criterion;
+use criterion::{criterion_group, criterion_main};
+use peekmore::{PeekMore, PeekMoreIterator};
+
+fn peek_at<I: Iterator>(
+    mut iterator: PeekMoreIterator<I>,
+    peek_at: impl IntoIterator<Item = usize>,
+) {
+    for i in peek_at {
+        let _ = iterator.peek_nth(i);
+        iterator.truncate_iterator_to_cursor();
+    }
+}
+
+const AMOUNT: usize = 10_000;
+const PEEK_STEP: usize = 4;
+const PEEK_TIMES: usize = AMOUNT / PEEK_STEP;
+
+fn peek_nth_benchmark(c: &mut Criterion) {
+    c.bench_function("peek_nth", move |b| {
+        b.iter(|| {
+            peek_at(
+                black_box((0..AMOUNT).peekmore()),
+                (0..PEEK_TIMES).map(|n| n * PEEK_STEP),
+            )
+        });
+    });
+}
+
+criterion_group!(benches, peek_nth_benchmark);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -1,0 +1,11 @@
+test:
+    cargo test --all
+
+bench:
+    cargo bench
+    cargo bench --features smallvec
+
+before-push:
+    cargo fmt --all
+    cargo clippy --all-targets --all-features -- -D warnings
+    cargo test --all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ impl<I: Iterator> PeekMore for I {
 /// Default stack size for SmallVec.
 /// Admittedly the current size is chosen quite arbitrarily.
 #[cfg(feature = "smallvec")]
-const DEFAULT_STACK_SIZE: usize = 256;
+const DEFAULT_STACK_SIZE: usize = 8;
 
 /// This iterator makes it possible to peek multiple times without consuming a value.
 /// In reality the underlying iterator will be consumed, but the values will be stored in a queue.


### PR DESCRIPTION
According to my first preliminary benchmarks, smallvec may not be a good fit as the default feature. I'm not sure if my benchmark is actually performed correctly, but disabling smallvec by default and keeping it as an option sounds like a safe choice.