### PR TITLE
Disable smallvec by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["no-std"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["smallvec"]
+default = []
 
 [dependencies.smallvec]
 version = "1.5.1"


### PR DESCRIPTION
The performance measurements seem a bit flaky, but the smaalvec performance in the current configuration is significantly slower (~12%) in various test cases. For that reason it feels safe to disable it by default, and keep it as an opt in option.