### PR TITLE
Remove cursor decrement from `advance_cursor_while`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1407,8 +1407,8 @@ mod tests {
         let _ = iter.advance_cursor_while(|i| **i.unwrap() != 3);
 
         let peek = iter.peek();
-        assert_eq!(peek, Some(&&2));
-        assert_eq!(iter.cursor(), 1);
+        assert_eq!(peek, Some(&&3));
+        assert_eq!(iter.cursor(), 2);
     }
 
     #[test]
@@ -1431,8 +1431,22 @@ mod tests {
         let _ = iter.advance_cursor_while(|i| i.is_some());
 
         let peek = iter.peek();
-        assert_eq!(peek, Some(&&4));
-        assert_eq!(iter.cursor(), 3);
+        assert_eq!(peek, None);
+        assert_eq!(iter.cursor(), 4);
+    }
+
+    #[test]
+    fn check_move_forward_while_fast_fail() {
+        let iterable = [1, 2, 3, 4];
+        let mut iter = iterable.iter().peekmore();
+
+        iter.advance_cursor_by(2);
+
+        let _ = iter.advance_cursor_while(|i| **i.unwrap() > 3);
+
+        let peek = iter.peek();
+        assert_eq!(peek, Some(&&3));
+        assert_eq!(iter.cursor(), 2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,6 +479,13 @@ impl<I: Iterator> PeekMoreIterator<I> {
     }
 
     /// Moves the cursor forward until the predicate is no longer `true`.
+    ///
+    /// After this method returns, the cursor points to the first element that fails `predicate`. If no peeked elements
+    /// pass `predicate` then the cursor will remain unchanged.
+    ///
+    /// This does not advance the iterator itself. To advance the iterator, call [`next()`] instead.
+    ///
+    /// [`next()`]: struct.PeekMoreIterator.html#impl-Iterator
     #[inline]
     pub fn advance_cursor_while<P: Fn(Option<&I::Item>) -> bool>(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,7 +490,6 @@ impl<I: Iterator> PeekMoreIterator<I> {
             self.increment_cursor();
             self.advance_cursor_while(predicate)
         } else {
-            self.decrement_cursor();
             self
         }
     }


### PR DESCRIPTION
This addresses the issues raised in #72.

The call to `decrement_cursor` has been removed and the method documentation has been expanded upon to communicate the behaviour a bit more explicitly.